### PR TITLE
Added sm Button, refactor api calls into its own hook + added Nudge D…

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "autoprefixer": "^9.7.3",
     "graphql": "^14.5.8",
     "lodash": "^4.17.15",
+    "moment": "^2.24.0",
     "postcss-cli": "^6.1.3",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
+    "react-moment": "^0.9.6",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.2.0",
     "tailwindcss": "^1.1.4"

--- a/src/app.js
+++ b/src/app.js
@@ -16,9 +16,23 @@ import LoginRoute from './routes/login';
 import SignupRoute from './routes/signup';
 import DashboardRoute from './routes/dashboard';
 
+import NudgeNewRoute from './routes/nudge/new';
+import NudgeUpdateRoute from './routes/nudge/update';
+import NudgeDeleteRoute from './routes/nudge/delete';
+
+import { STORAGE_AUTH_KEY } from './hooks/use-provide-auth';
+
 function App() {
   const client = new ApolloClient({
     uri: 'http://localhost:3000/graphql',
+    request: (operation) => {
+      const token = localStorage.getItem(STORAGE_AUTH_KEY);
+      operation.setContext({
+        headers: {
+          authorization: token ? `Bearer ${token}` : '',
+        },
+      });
+    },
   });
 
   return (
@@ -29,9 +43,12 @@ function App() {
             <Route exact path="/">
               <Redirect push to="/login" />
             </Route>
-            <UnauthenticatedRoute path="/login" component={LoginRoute} />
-            <UnauthenticatedRoute path="/signup" component={SignupRoute} />
-            <ProtectedRoute path="/dashboard" component={DashboardRoute} />
+            <UnauthenticatedRoute path={LoginRoute.path} component={LoginRoute} />
+            <UnauthenticatedRoute path={SignupRoute.path} component={SignupRoute} />
+            <ProtectedRoute path={DashboardRoute.path} component={DashboardRoute} />
+            <ProtectedRoute path={NudgeNewRoute.path} component={NudgeNewRoute} />
+            <ProtectedRoute path={NudgeUpdateRoute.path} component={NudgeUpdateRoute} />
+            <ProtectedRoute path={NudgeDeleteRoute.path} component={NudgeDeleteRoute} />
           </ProvideAuth>
         </Switch>
       </BrowserRouter>

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -3,10 +3,26 @@ import PropTypes from 'prop-types';
 
 import { useClassNameHelper } from '../../hooks/use-class-name-helper';
 
+const CLASS_NAMES_SIZE_MAPPING = {
+  sm: [
+    'py-1',
+    'px-2',
+    'text-xs',
+    'font-bold',
+  ],
+
+  md: [
+    'py-2',
+    'px-4',
+    'text-sm',
+    'font-bold',
+  ],
+};
+
 function Button(props) {
   // props
   const {
-    className, type, onClick, label,
+    className, type, size, onClick, label,
   } = props;
 
   // hooks
@@ -15,14 +31,11 @@ function Button(props) {
       'bg-blue-500',
       'hover:bg-blue-400',
       'text-white',
-      'font-bold',
-      'py-2',
-      'px-4',
       'border-b-4',
       'border-blue-700',
       'hover:border-blue-500',
       'rounded',
-    ]);
+    ], CLASS_NAMES_SIZE_MAPPING[size]);
 
   return (
     <button type={type} onClick={onClick} className={ch.get('btn', className)}>
@@ -36,13 +49,15 @@ Button.propTypes = {
   label: PropTypes.string,
   onClick: PropTypes.func,
   type: PropTypes.oneOf(['button', 'submit', 'reset']),
+  size: PropTypes.oneOf(['sm', 'md']),
 };
 
 Button.defaultProps = {
-  type: 'button',
-  className: null,
-  label: null,
+  className: undefined,
+  label: undefined,
   onClick: () => {},
+  type: 'button',
+  size: 'md',
 };
 
 export default Button;

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import uniqueId from 'lodash/uniqueId';
+
+import { useClassNameHelper } from '../../hooks/use-class-name-helper';
+
+function Checkbox(props) {
+  // props
+  const {
+    checked, className, label, onChange,
+  } = props;
+
+  // hooks
+  const ch = useClassNameHelper()
+    .register('container', [
+      'py-2',
+      'flex',
+      'items-center',
+    ])
+    .register('label', [
+      'mr-2',
+    ]);
+
+  const [id] = useState(() => uniqueId('input-'));
+
+  return (
+    <div className={ch.get('container', className)}>
+      <label htmlFor={id} className={ch.get('label')}>
+        {label}
+        :
+      </label>
+      <input id={id} type="checkbox" checked={checked} onChange={onChange} />
+    </div>
+  );
+}
+
+Checkbox.propTypes = {
+  checked: PropTypes.bool,
+  className: PropTypes.string,
+  label: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+};
+
+Checkbox.defaultProps = {
+  checked: undefined,
+  className: undefined,
+  onChange: () => {},
+};
+
+export default Checkbox;

--- a/src/components/checkbox/index.js
+++ b/src/components/checkbox/index.js
@@ -1,0 +1,1 @@
+export { default } from './checkbox';

--- a/src/components/dashboard/dashboard.js
+++ b/src/components/dashboard/dashboard.js
@@ -1,29 +1,64 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
 
+import Nudge from '../nudge';
 import Button from '../button';
+import { PATH as LoginPath } from '../../routes/login';
+import { PATH as NudgeNewPath } from '../../routes/nudge/new';
 import { useAuth } from '../../hooks/use-auth';
+import { useClassNameHelper } from '../../hooks/use-class-name-helper';
+import { useNudgeApi } from '../../hooks/use-nudge-api';
 
-function Dashboard() {
+function Dashboard(props) {
+  // props
+  const { className } = props;
+
   // hooks
-  const { isAuthenticated, logout } = useAuth();
+  const { logout } = useAuth();
   const history = useHistory();
+  const { getNudges } = useNudgeApi();
+  const { loading, error, data } = getNudges();
+  const ch = useClassNameHelper()
+    .register('container', [
+      'border',
+      'border-gray-400',
+      'bg-white',
+      'p-4',
+      'rounded',
+    ]);
 
   // handlers
   const logoutAndRedirect = () => {
     logout();
-    history.push('/login');
+    history.push(LoginPath);
   };
 
+  if (loading) return 'Loading...';
+  if (error) return <Button label="Log out" onClick={logoutAndRedirect} />;
+
   return (
-    <div className="border border-gray-400 bg-white p-4 rounded h-64 w-64">
-      <p>
-        Authenticated:
-        {isAuthenticated()}
-      </p>
-      <Button label="Log out" onClick={logoutAndRedirect} />
+    <div className={ch.get('container', className)}>
+      {
+        data.getNudges.map((nudge) => (
+          <Nudge key={nudge.id} nudge={nudge} />
+        ))
+      }
+      <hr className="my-2" />
+      <div className="flex items-center justify-end">
+        <Button label="Add a Nudge" onClick={() => history.push(NudgeNewPath)} />
+      </div>
+      <Button label="Log out" className="inline-block" onClick={logoutAndRedirect} />
     </div>
   );
 }
+
+Dashboard.propTypes = {
+  className: PropTypes.string,
+};
+
+Dashboard.defaultProps = {
+  className: undefined,
+};
 
 export default Dashboard;

--- a/src/components/form-error/form-error.js
+++ b/src/components/form-error/form-error.js
@@ -35,8 +35,8 @@ FormError.propTypes = {
 };
 
 FormError.defaultProps = {
-  className: null,
-  message: null,
+  className: undefined,
+  message: undefined,
 };
 
 export default FormError;

--- a/src/components/form-login/form-login.js
+++ b/src/components/form-login/form-login.js
@@ -46,7 +46,7 @@ FormLogin.propTypes = {
 
 FormLogin.defaultProps = {
   onSubmit: () => {},
-  className: null,
+  className: undefined,
 };
 
 export default FormLogin;

--- a/src/components/form-nudge/form-nudge.js
+++ b/src/components/form-nudge/form-nudge.js
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+import Input from '../input';
+import Checkbox from '../checkbox';
+import Button from '../button';
+import FormError from '../form-error';
+
+function FormNudge(props) {
+  // props
+  const {
+    className,
+    onSubmit,
+    name,
+    color,
+    // archived,
+    public: pub,
+  } = props;
+
+  // hooks
+  const [_name, setName] = useState(name);
+  const [_color, setColor] = useState(color);
+  // const [_archived, setArchived] = useState(archived);
+  const [_public, setPublic] = useState(pub);
+  const [errorMessage, setErrorMessage] = useState();
+
+  // handlers
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit({
+      name: _name,
+      color: _color,
+      // archived: _archived,
+      public: _public,
+    }).catch((error) => setErrorMessage(error.message));
+  };
+
+  return (
+    <div className={className}>
+      <form onSubmit={handleSubmit} className="flex flex-col border-2 border-gray-400 bg-white p-4 rounded">
+        <Input type="text" label="Name" value={_name} onChange={(e) => setName(e.target.value)} />
+        <Input type="text" label="Color" value={_color} onChange={(e) => setColor(e.target.value)} />
+        {/*<Checkbox label="Archived" value={_archived} onChange={(e) => setArchived(e.target.value)} />*/}
+        <Checkbox label="Public" value={_public} onChange={(e) => setPublic(e.target.value)} />
+        <Button label="Submit" type="submit" />
+        { errorMessage && <FormError message={errorMessage} className="mt-4" />}
+      </form>
+    </div>
+  );
+}
+
+FormNudge.propTypes = {
+  className: PropTypes.string,
+  onSubmit: PropTypes.func,
+  name: PropTypes.string,
+  color: PropTypes.string,
+  archived: PropTypes.bool,
+  public: PropTypes.bool,
+};
+
+FormNudge.defaultProps = {
+  onSubmit: () => {},
+  className: undefined,
+  name: undefined,
+  color: undefined,
+  archived: undefined,
+  public: undefined,
+};
+
+export default FormNudge;

--- a/src/components/form-nudge/index.js
+++ b/src/components/form-nudge/index.js
@@ -1,0 +1,1 @@
+export { default } from './form-nudge';

--- a/src/components/form-signup/form-signup.js
+++ b/src/components/form-signup/form-signup.js
@@ -48,7 +48,7 @@ FormSignup.propTypes = {
 
 FormSignup.defaultProps = {
   onSubmit: () => {},
-  className: null,
+  className: undefined,
 };
 
 export default FormSignup;

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -58,7 +58,7 @@ Input.propTypes = {
 };
 
 Input.defaultProps = {
-  value: '', // @todo: why undefined creates an uncontroller/controller component switch?
+  value: '', // @todo: why undefined creates an uncontrolled/controlled component switch?
   className: undefined,
   onChange: () => {},
 };

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -13,7 +13,6 @@ function Input(props) {
   // hooks
   const ch = useClassNameHelper()
     .register('label', [
-      'bg-white',
       'py-2',
       'inline-block',
       'w-full',
@@ -59,8 +58,8 @@ Input.propTypes = {
 };
 
 Input.defaultProps = {
-  value: '',
-  className: null,
+  value: '', // @todo: why undefined creates an uncontroller/controller component switch?
+  className: undefined,
   onChange: () => {},
 };
 

--- a/src/components/nudge/index.js
+++ b/src/components/nudge/index.js
@@ -1,0 +1,1 @@
+export { default } from './nudge';

--- a/src/components/nudge/nudge.js
+++ b/src/components/nudge/nudge.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Moment from 'react-moment';
+import { useHistory } from 'react-router-dom';
+
+import Button from '../button';
+import { path as nudgeUpdatePath } from '../../routes/nudge/update';
+import { path as nudgeDeletePath } from '../../routes/nudge/delete';
+import { useClassNameHelper } from '../../hooks/use-class-name-helper';
+
+function Nudge({ nudge }) {
+  const history = useHistory();
+  const ch = useClassNameHelper()
+    .register('color', [
+      'inline-block',
+      'w-4',
+      'h-4',
+      'border',
+      'border-gray-500',
+      'rounded-sm',
+      'mr-2',
+    ]);
+
+  const handleEdit = () => history.push(nudgeUpdatePath(nudge.id));
+  const handleDelete = () => history.push(nudgeDeletePath(nudge.id));
+
+  return (
+    <div className="flex items-center">
+      <span style={{ backgroundColor: nudge.color }} className={ch.get('color')} />
+      <span className="flex-grow">{nudge.name}</span>
+      <span className="px-4">{nudge.archived ? <span role="img" aria-label="checkmark">✅</span> : ''}</span>
+      <span className="px-4">{nudge.public ? <span role="img" aria-label="checkmark">✅</span> : ''}</span>
+      <Moment className="px-4 lowercase" date={nudge.createdAt} format="d MMM." />
+      <Moment className="px-4 lowercase" date={nudge.updatedAt} format="d MMM." />
+      <span className="pr-1"><Button type="button" size="sm" onClick={handleEdit} label="Edit" /></span>
+      <span><Button type="button" size="sm" onClick={handleDelete} label="Delete" /></span>
+    </div>
+  );
+}
+
+Nudge.propTypes = {
+  nudge: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+    color: PropTypes.string,
+    archived: PropTypes.string,
+    public: PropTypes.string,
+    createdAt: PropTypes.string,
+    updatedAt: PropTypes.string,
+  }).isRequired,
+};
+
+export default Nudge;

--- a/src/hooks/use-class-name-helper.js
+++ b/src/hooks/use-class-name-helper.js
@@ -3,16 +3,18 @@ class ClassNameHelper {
     this.classMapping = {};
   }
 
-  register(key, classes) {
+  register(key, ...classNameArrays) {
     if (!this.classMapping[key]) {
       this.classMapping[key] = [];
     }
 
-    if (Array.isArray(classes)) {
-      this.classMapping[key] = this.classMapping[key].concat(classes);
-    } else {
-      this.classMapping[key].push(classes);
-    }
+    classNameArrays.forEach((classNameArray) => {
+      if (!Array.isArray(classNameArray)) {
+        throw new Error('Arguments after key must be arrays');
+      }
+
+      this.classMapping[key] = this.classMapping[key].concat(classNameArray);
+    });
 
     return this;
   }

--- a/src/hooks/use-nudge-api.js
+++ b/src/hooks/use-nudge-api.js
@@ -1,0 +1,80 @@
+import { gql } from 'apollo-boost';
+import { useQuery, useMutation } from '@apollo/react-hooks';
+
+/**
+ * Queries
+ */
+const GET_NUDGES = gql`
+  {
+    getNudges {
+      id
+      name
+      color
+      archived
+      public
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
+/**
+ * Mutations
+ */
+
+const CREATE_NUDGE_MUTATION = gql`
+  mutation createNudge($name: String!, $color: String!, $public: Boolean) {
+    createNudge(name: $name, color: $color, public: $public) {
+      id
+      name
+      color
+      archived
+      public
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
+const CREATE_USER_MUTATION = gql`
+  mutation login($email: String!, $password: String!, $name: String!) {
+    createUser(email: $email, password: $password, name: $name) {
+      id
+      email
+      name
+      jwt
+    }
+  }
+`;
+
+const LOGIN_MUTATION = gql`
+  mutation login($email: String!, $password: String!) {
+    login(email: $email, password: $password) {
+      id
+      email
+      name
+      jwt
+    }
+  }
+`;
+
+export const useNudgeApi = () => {
+  const [createNudgeMutation] = useMutation(CREATE_NUDGE_MUTATION);
+  const [createUserMutation] = useMutation(CREATE_USER_MUTATION);
+  const [loginMutation] = useMutation(LOGIN_MUTATION);
+  const getNudgesQuery = useQuery(GET_NUDGES);
+
+  const createNudge = (variables) => createNudgeMutation({ variables });
+  const createUser = (variables) => createUserMutation({ variables });
+  const getNudges = () => getNudgesQuery;
+  const login = (variables) => loginMutation({ variables });
+
+  return {
+    createNudge,
+    createUser,
+    getNudges,
+    login,
+  };
+};
+
+export default useNudgeApi;

--- a/src/routes/create-nudge.js
+++ b/src/routes/create-nudge.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+
+import FormNudge from '../components/form-nudge';
+import { PATH as DashboardPath } from './dashboard';
+import { useNudgeApi } from '../hooks/use-nudge-api';
+
+function CreateNudgeRoute() {
+  const { createNudge } = useNudgeApi();
+  const history = useHistory();
+
+  const handleSubmit = (variables) => createNudge(variables).then(() => history.push(DashboardPath));
+
+  return (
+    <div className="mt-32 flex justify-center items-center">
+      <FormNudge className="w-1/4" onSubmit={handleSubmit} />
+    </div>
+  );
+}
+
+export default CreateNudgeRoute;

--- a/src/routes/dashboard.js
+++ b/src/routes/dashboard.js
@@ -2,12 +2,16 @@ import React from 'react';
 
 import Dashboard from '../components/dashboard';
 
+export const PATH = '/dashboard';
+
 function DashboardRoute() {
   return (
     <div className="mt-32 flex justify-center items-center">
-      <Dashboard className="w-1/4" />
+      <Dashboard className="w-2/3" />
     </div>
   );
 }
+
+DashboardRoute.path = PATH;
 
 export default DashboardRoute;

--- a/src/routes/login.js
+++ b/src/routes/login.js
@@ -3,6 +3,8 @@ import React from 'react';
 import FormLogin from '../components/form-login';
 import { useAuth } from '../hooks/use-auth';
 
+export const PATH = '/login';
+
 function Login() {
   const { login } = useAuth();
 
@@ -12,5 +14,7 @@ function Login() {
     </div>
   );
 }
+
+Login.path = PATH;
 
 export default Login;

--- a/src/routes/nudge/delete.js
+++ b/src/routes/nudge/delete.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { PATH as DashboardPath } from '../dashboard';
+
+export const PATH = '/nudge/delete/:id';
+export const path = (id) => PATH.replace(':id', id);
+
+function NudgeDelete() {
+  return (
+    <div>
+      <Link to={DashboardPath}>back to Dashboard</Link>
+    </div>
+  );
+}
+
+NudgeDelete.path = PATH;
+
+export default NudgeDelete;

--- a/src/routes/nudge/new.js
+++ b/src/routes/nudge/new.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+
+import FormNudge from '../../components/form-nudge';
+import { PATH as DashboardPath } from '../dashboard';
+import { useNudgeApi } from '../../hooks/use-nudge-api';
+
+export const PATH = '/nudge/new';
+
+function NewNudge() {
+  const { createNudge } = useNudgeApi();
+  const history = useHistory();
+
+  const handleSubmit = (variables) => createNudge(variables).then(() => history.push(DashboardPath));
+
+  return (
+    <div className="mt-32 flex justify-center items-center">
+      <FormNudge className="w-1/4" onSubmit={handleSubmit} />
+    </div>
+  );
+}
+
+NewNudge.path = PATH;
+
+export default NewNudge;

--- a/src/routes/nudge/update.js
+++ b/src/routes/nudge/update.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { PATH as DashboardPath } from '../dashboard';
+
+export const PATH = '/nudge/update/:id';
+export const path = (id) => PATH.replace(':id', id);
+
+function NudgeUpdate() {
+  return (
+    <Link to={DashboardPath}>back to Dashboard</Link>
+  );
+}
+
+NudgeUpdate.path = PATH;
+
+export default NudgeUpdate;

--- a/src/routes/signup.js
+++ b/src/routes/signup.js
@@ -3,6 +3,8 @@ import React from 'react';
 import FormSignup from '../components/form-signup';
 import { useAuth } from '../hooks/use-auth';
 
+export const PATH = '/signup';
+
 function Signup() {
   const { signup } = useAuth();
 
@@ -12,5 +14,7 @@ function Signup() {
     </div>
   );
 }
+
+Signup.path = PATH;
 
 export default Signup;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6736,6 +6736,11 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -8665,6 +8670,11 @@ react-is@^16.8.1, react-is@^16.8.4:
   version "16.10.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.10.1.tgz#0612786bf19df406502d935494f0450b40b8294f"
   integrity sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw==
+
+react-moment@^0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/react-moment/-/react-moment-0.9.6.tgz#6b359a48205a52196408303e30bc982cd46d0bee"
+  integrity sha512-GAnd5NRIpGjDqLoGahJCkiCEQS1d8+dIZbIfPuy/eQ0O5Rio43fEkj5G+qrKbZCQY55fiNafpHpuirVIHqPoSg==
 
 react-router-dom@^5.1.2:
   version "5.1.2"


### PR DESCRIPTION
- Added react-moment
- Read JWT from storage and pass it to ApolloClient for subsequent authenticated requests.
- Added Nudge Create/Update/Delete routes
- Implemented Nudge Create route
- Refactor Button to offer an additional size
- Added Checkbox
- Refactor path usage to be used through constants instead of strings.
- Extract GraphQL queries and mutations in its own hook
- Various cleanups + ui improvements
